### PR TITLE
Docker: Add Dockerfile and .dockerignore for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target
+.git
+Dockerfile
+README.md
+LICENSE
+*.swp
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM rust:slim
+WORKDIR /app
+CMD ["cargo", "run"]

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod jwt;

--- a/src/routes/auth/login.rs
+++ b/src/routes/auth/login.rs
@@ -37,7 +37,6 @@ pub async fn login(
     match hashing::verify_password(&password, &password_hash) {
         Ok(is_match) => {
             if is_match {
-                // Issue JWT here
                 let jwt: String = jwt::generate_jwt(&email, keep_logged_in)
                     .map_err(|e| error::ErrorInternalServerError(e))?;
 

--- a/src/services/jwt/mod.rs
+++ b/src/services/jwt/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use jsonwebtoken::{encode, EncodingKey, Header};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -49,6 +49,20 @@ pub fn generate_jwt(sub: &str, long_lived: &bool) -> Result<String> {
         // An EncodingKey wrapper is used because rather than passing the bytes directly as this
         // provides a uniform interface for different key types (from_secret, from_ec_pem, etc.)
         &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|e| anyhow!(e))
+}
+
+// TokenData is a struct that holds your decoded claims (Claims instance), and a Header instance
+pub fn verify_jwt(token: &str) -> Result<TokenData<Claims>> {
+    let secret: String = std::env::var("JWT_SECRET").map_err(|_| anyhow!("JWT_SECRET not set"))?;
+
+    decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(&secret.as_bytes()),
+        // A Validation struct defines the validation rules when decoding a JWT. The
+        // Validation::default() function returns an instance that assumes HS256
+        &Validation::default(),
     )
     .map_err(|e| anyhow!(e))
 }


### PR DESCRIPTION
This PR adds basic Docker support for local support using the rust:slim image. This setup is intended for development only. A production ready multistage build will be added later.